### PR TITLE
이메일 인증 코드를 Redis에 일시 저장하도록 변경 #1

### DIFF
--- a/src/main/java/team/rescue/auth/controller/AuthController.java
+++ b/src/main/java/team/rescue/auth/controller/AuthController.java
@@ -26,7 +26,6 @@ import team.rescue.auth.service.AuthService;
 import team.rescue.auth.type.ProviderType;
 import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.dto.ResponseDto;
-import team.rescue.member.dto.MemberDto.MemberInfoWithTokenDto;
 
 @Slf4j
 @RestController
@@ -69,8 +68,8 @@ public class AuthController {
 	 * @return 확인 여부 반환
 	 */
 	@PostMapping("/email/confirm")
-	@PreAuthorize("permitAll()")
-	public ResponseEntity<ResponseDto<MemberInfoWithTokenDto>> emailConfirm(
+	@PreAuthorize("hasAuthority('GUEST')")
+	public ResponseEntity<ResponseDto<String>> emailConfirm(
 			@RequestBody @Valid JoinDto.EmailConfirmDto emailConfirmDto,
 			BindingResult bindingResult,
 			@AuthenticationPrincipal PrincipalDetails details
@@ -78,17 +77,11 @@ public class AuthController {
 
 		log.info("[이메일 코드 확인] code={}", emailConfirmDto.getCode());
 
-		MemberInfoWithTokenDto memberInfoDto = null;
+		String accessToken =
+				authService.confirmEmailCode(details.getUsername(), emailConfirmDto.getCode());
 
-		if (details == null) {
-			memberInfoDto = authService.confirmEmailCode(emailConfirmDto.getEmail(),
-					emailConfirmDto.getCode());
-		} else {
-			memberInfoDto = authService
-					.confirmEmailCode(details.getUsername(), emailConfirmDto.getCode());
-		}
 		return new ResponseEntity<>(
-				new ResponseDto<>(null, memberInfoDto), HttpStatus.OK
+				new ResponseDto<>(null, accessToken), HttpStatus.OK
 		);
 	}
 

--- a/src/main/java/team/rescue/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/team/rescue/auth/filter/JwtAuthenticationFilter.java
@@ -47,8 +47,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 	private static final String TOKEN_PREFIX = "Bearer ";
 	private static final String HEADER_ACCESS_TOKEN = "Access-Token";
 	private static final String HEADER_REFRESH_TOKEN = "Refresh-Token";
-	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;   // 24h
-
 	private final ObjectMapper objectMapper;
 	private final AuthenticationManager authenticationManager;
 	private final RedisRepository redisUtil;
@@ -124,8 +122,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		redisUtil.put(
 				RedisPrefix.TOKEN,
 				principalDetails.getUsername(),
-				refreshToken,
-				REFRESH_TOKEN_EXPIRE_TIME
+				refreshToken
 		);
 
 		// access token을 Response Body에 담아서 클라이언트에게 전달

--- a/src/main/java/team/rescue/auth/handler/OAuthAuthorizationSuccessHandler.java
+++ b/src/main/java/team/rescue/auth/handler/OAuthAuthorizationSuccessHandler.java
@@ -54,12 +54,7 @@ public class OAuthAuthorizationSuccessHandler implements AuthenticationSuccessHa
 
 		saveRefreshToken(principalDetails, refreshToken);
 
-		redisRepository.put(
-				RedisPrefix.TOKEN,
-				principalDetails.getUsername(),
-				refreshToken,
-				REFRESH_TOKEN_EXPIRE_TIME
-		);
+		redisRepository.put(RedisPrefix.TOKEN, principalDetails.getUsername(), refreshToken);
 
 		// access token은 Response Body에 담아서 클라이언트에게 전달
 		LoginResDto loginResponse = new LoginResDto(principalDetails.getMember(), accessToken);

--- a/src/main/java/team/rescue/auth/service/AuthService.java
+++ b/src/main/java/team/rescue/auth/service/AuthService.java
@@ -102,7 +102,7 @@ public class AuthService implements UserDetailsService {
 		log.info("[인증 메일 전송] email={}", member.getEmail());
 
 		String emailCode = mailProvider.sendEmail(member);
-		member.updateEmailCode(emailCode);
+//		member.updateEmailCode(emailCode);
 
 		log.info("[인증 메일 전송 완료]");
 

--- a/src/main/java/team/rescue/common/redis/RedisPrefix.java
+++ b/src/main/java/team/rescue/common/redis/RedisPrefix.java
@@ -1,7 +1,16 @@
 package team.rescue.common.redis;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum RedisPrefix {
 
-	TOKEN, CODE
+	TOKEN("TOKEN_", 1000 * 60 * 60 * 24L),
+	CODE("CODE_", 1000 * 60 * 10L);
+
+	private final String prefix;
+	private final Long expiredTime;
 
 }

--- a/src/main/java/team/rescue/common/redis/RedisRepository.java
+++ b/src/main/java/team/rescue/common/redis/RedisRepository.java
@@ -10,27 +10,25 @@ import org.springframework.stereotype.Component;
 public class RedisRepository {
 
 	private final RedisTemplate<String, Object> redisTemplate;
-	private static final String REDIS_KEY_SEPARATOR = "_";
 
-	public void put(RedisPrefix prefix, String key, Object value, Long expirationTime) {
-		if (expirationTime != null) {
-			redisTemplate.opsForValue().set(
-					prefix.name() + REDIS_KEY_SEPARATOR + key, value, expirationTime, TimeUnit.SECONDS
-			);
-		} else {
-			redisTemplate.opsForValue().set(key, value);
-		}
+	public void put(RedisPrefix prefix, String key, Object value) {
+		redisTemplate.opsForValue().set(
+				prefix.name() + key,
+				value,
+				prefix.getExpiredTime(),
+				TimeUnit.SECONDS
+		);
 	}
 
 	public void delete(String key) {
 		redisTemplate.delete(key);
 	}
 
-	public Object get(String key) {
+	public String get(String key) {
 
 		// key에 해당하는 값이 존재하면 해당 값 반환
 		if (isExists(key)) {
-			return redisTemplate.opsForValue().get(key);
+			return (String) redisTemplate.opsForValue().get(key);
 		} else {
 			return null;
 		}

--- a/src/main/java/team/rescue/common/redis/RedisRepository.java
+++ b/src/main/java/team/rescue/common/redis/RedisRepository.java
@@ -13,7 +13,7 @@ public class RedisRepository {
 
 	public void put(RedisPrefix prefix, String key, Object value) {
 		redisTemplate.opsForValue().set(
-				prefix.name() + key,
+				prefix.getPrefix() + key,
 				value,
 				prefix.getExpiredTime(),
 				TimeUnit.SECONDS

--- a/src/main/java/team/rescue/member/entity/Member.java
+++ b/src/main/java/team/rescue/member/entity/Member.java
@@ -63,10 +63,6 @@ public class Member {
 	@Column(name = "provider_id", length = 100)
 	private String providerId;
 
-	// Email 가입 시 인증 코드
-	@Column(name = "email_code", length = 10)
-	private String emailCode;
-
 	@Column(name = "jwt_token")
 	private String token;
 
@@ -98,10 +94,6 @@ public class Member {
 	@LastModifiedDate
 	@Column(name = "modified_at")
 	private LocalDateTime modifiedAt;
-
-	public void updateEmailCode(String emailCode) {
-		this.emailCode = emailCode;
-	}
 
 	public void updateRole(RoleType role) {
 		this.role = role;


### PR DESCRIPTION
### 작업 내용 요약 
- RedisPrefix Enum으로 관리하여 Redis 저장 시 Prefix, 만료 시간 강제하도록 변경
- Member Entity에서 emailCode 필드 제거
- 이메일 인증 코드를 Redis에 일시적으로 저장하도록 로직 수정

### 변경점

#### RedisPrefix Enum으로 관리하여 Redis 저장 시 Prefix, 만료 시간 강제하도록 변경
RedisRepository 클래스를 이용해 Redis에 값을 저장할 때,
Prefix와 유효 시간 설정을 강제하도록 Enum 타입을 생성하고, RedisRepository 메서드를 일부 변경했습니다.
JWT Refresh Token을 저장할 때 따로 Prefix 설정이 없었고, 
유효 시간은 JWT Token 관련 필터에서 static 필드로 설정하여 여러 클래스에 유효 시간에 대한 정보가 산재해 있었습니다. 

```java
@Getter
@RequiredArgsConstructor
public enum RedisPrefix {

	TOKEN("TOKEN_", 1000 * 60 * 60 * 24L),
	CODE("CODE_", 1000 * 60 * 10L);

	private final String prefix;
	private final Long expiredTime;
}
```

따라서 RedisRepository에 put 메서드로 데이터를 저장하는 메서드의 파라미터로 RedisPrefix Enum을 넘기도록 변경했습니다.

```java
public void put(RedisPrefix prefix, String key, Object value) {
	redisTemplate.opsForValue().set(
		prefix.getPrefix() + key,
		value,
		prefix.getExpiredTime(),
		TimeUnit.SECONDS
    );
}
```
이메일 인증 코드 저장 시 다음과 같이 Prefix를 설정해 Redis Key로 저장합니다.

```java
// 인증 코드 생성 및 전송
String emailCode = mailProvider.sendEmail(member);

// 인증 코드 Redis 저장
redisRepository.put(RedisPrefix.CODE, member.getEmail(), emailCode);
```

#### 이메일 인증 코드를 Redis에 일시적으로 저장하도록 로직 수정
기존에는 Member Table의 email_code 필드에 Email 인증 코드를 저장했으나,
이메일 인증 코드 특성 상 최초 회원 가입시 부터 이메일 인증 완료 시점까지 한 번만 사용되므로 RDB에서 관리하기보다
Redis로 일시 저장하고, 이메일 인증이 완료되면 제거하는 쪽이 효율적이라 생각됩니다.


